### PR TITLE
Fix relative paths for hotspot scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Guidelines for agents working on this repository
+
+This repository contains scripts that generate hotspot maps for Indonesia.
+
+## Setup
+
+1. **Python version**: Use Python 3.11 or newer.
+2. **Virtual environment**: Create a virtual environment named `hs` in the repository root:
+   ```bash
+   python3 -m venv hs
+   source hs/bin/activate
+   ```
+3. **Dependencies**: Install packages required by the scripts:
+   ```bash
+   pip install pandas geopandas matplotlib shapely
+   ```
+
+## Running
+
+- To generate the hotspot map, execute:
+  ```bash
+  bash scripts/run_hotspot.sh
+  ```
+  The output image will be written to `images/update_hotspot.png`.
+
+## Style and testing
+
+- Format Python code with `black` before committing:
+  ```bash
+  black scripts/hotspot_map.py
+  ```
+- There is no automated test suite. Running `python3 scripts/hotspot_map.py` is recommended to verify the environment.

--- a/scripts/hotspot_map.py
+++ b/scripts/hotspot_map.py
@@ -7,13 +7,16 @@ from matplotlib.offsetbox import OffsetImage, AnnotationBbox
 import matplotlib.image as mpimg
 import datetime
 import os
+from pathlib import Path
 
-# === Set working directory ===
-os.chdir(os.path.expanduser("./"))
+# === Resolve project directories ===
+# Determine the project root based on this file's location so that the
+# script works regardless of the current working directory.
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # === Load and clean data from TXT ===
-txt_file = "Hotspot_Indonesia.txt"
-csv_file = "Hotspot_Indonesia.csv"
+txt_file = BASE_DIR / "data" / "Hotspot_Indonesia.txt"
+csv_file = BASE_DIR / "data" / "Hotspot_Indonesia.csv"
 
 with open(txt_file, 'r') as file:
     lines = file.readlines()
@@ -56,8 +59,8 @@ region_counts = {
 }
 
 # === Load shapefiles ===
-shp_indonesia = gpd.read_file("shp/Indonesia_38_Provinsi.shp")
-shp_others = gpd.read_file("shp/world_without_idn.shp")
+shp_indonesia = gpd.read_file(BASE_DIR / "shp" / "Indonesia_38_Provinsi.shp")
+shp_others = gpd.read_file(BASE_DIR / "shp" / "world_without_idn.shp")
 
 # === Create map ===
 fig, ax = plt.subplots(figsize=(10, 7.5))
@@ -124,7 +127,8 @@ ax.text(98.8, -16.2, f'Tanggal: {today.strftime("%d-%m-%Y")}', family='monospace
 ax.text(98.8, -17.2, 'Satelit: Terra, Aqua, Suomi NPP, NOAA-20, dan NOAA-21', family='monospace')
 
 try:
-    logo = mpimg.imread("logo_bmkg.png")
+    logo_path = BASE_DIR / "images" / "logo_bmkg.png"
+    logo = mpimg.imread(logo_path)
     imagebox = OffsetImage(logo, zoom=0.15)
     ab = AnnotationBbox(imagebox, (97.3, -16.0), frameon=False)
     ax.add_artist(ab)
@@ -132,7 +136,8 @@ except FileNotFoundError:
     print("BMKG logo not found")
 
 plt.tight_layout()
-plt.savefig("update_hotspot.png", dpi=150)
+output_path = BASE_DIR / "images" / "update_hotspot.png"
+plt.savefig(output_path, dpi=150)
 
 print("Work has been completed.")
 

--- a/scripts/run_hotspot.sh
+++ b/scripts/run_hotspot.sh
@@ -8,6 +8,7 @@ else
     echo "Virtual environment not found at hs/bin/activate"
 fi
 
-python3 hotspot_map.py
+SCRIPT_DIR="$(dirname "$0")"
+python3 "$SCRIPT_DIR/hotspot_map.py"
 
 deactivate


### PR DESCRIPTION
## Summary
- resolve project root in `hotspot_map.py`
- load data, shapefiles, and assets using absolute paths
- save output map image to the `images` folder
- run the Python script from the correct directory in `run_hotspot.sh`

## Testing
- `python3 -m py_compile scripts/hotspot_map.py`
- `bash -n scripts/run_hotspot.sh`
- `python3 scripts/hotspot_map.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683f8a2997ec832980b41825392533aa